### PR TITLE
Update sentry requirement from 0.18.0 to 0.19.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocket-sentry"
-version = "0.2.0"
+version = "0.3.0-beta.0"
 edition = "2018"
 
 # Metadata
@@ -16,5 +16,5 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-sentry = "0.18.0"
+sentry = "0.19.0"
 rocket = { version = "0.4.2", default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ use std::sync::Mutex;
 
 use rocket::fairing::{Fairing, Info, Kind};
 use rocket::Rocket;
-use sentry::internals::ClientInitGuard;
+use sentry::ClientInitGuard;
 
 pub struct RocketSentry {
     guard: Mutex<Option<ClientInitGuard>>,
@@ -60,15 +60,10 @@ impl RocketSentry {
             let mut self_guard = self.guard.lock().unwrap();
             *self_guard = Some(guard);
 
-            self.configure();
             println!("Sentry enabled.");
         } else {
             println!("Sentry did not initialize.");
         }
-    }
-
-    fn configure(&self) {
-        sentry::integrations::panic::register_panic_handler();
     }
 }
 


### PR DESCRIPTION
* `register_panic_handler()` is no longer needed, the handler is
 installed automatically.
  See https://github.com/getsentry/sentry-rust/issues/235
* Running `cargo update` may be necessary due to
  https://github.com/SergioBenitez/Rocket/issues/1377