### PR TITLE
Update to Rocket 0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-sentry = "0.23"
-rocket = { version = "0.4", default-features = false }
-log = "0.4"
+sentry = "0.23.0"
+rocket = { version = "0.5.0-rc.1", default-features = false }
+log = "0.4.14"
+serde = "1.0.130"
+figment = "0.10.6"

--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ to your code:
 ```rust
 use rocket_sentry::RocketSentry;
 
-fn main() {
-    rocket::ignite()
+#[launch]
+fn rocket() -> _ {
+    rocket::build()
         .attach(RocketSentry::fairing())
         // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   add this line
-        .launch();
 }
 ```
 
@@ -44,11 +44,9 @@ Then, the Sentry integration can be enabled by adding a `sentry_dsn=` value to
 the `Rocket.toml` file, for example:
 
 ```toml
-[development]
+[debug]
 sentry_dsn = ""  # Disabled
-[staging]
-sentry_dsn = "https://057006d7dfe5fff0fbed461cfca5f757@sentry.io/1111111"
-[production]
+[release]
 sentry_dsn = "https://057006d7dfe5fff0fbed461cfca5f757@sentry.io/1111111"
 ```
 
@@ -59,7 +57,6 @@ The functionality can be tested with the `examples/panic.rs` example. Just
 change the `Rocket.toml` file and run it...
 
 ```shell script
-rustup override set nightly
 cargo run --example panic
 ```
 

--- a/Rocket.toml
+++ b/Rocket.toml
@@ -1,4 +1,4 @@
-# Rocket.toml file for examples/*
+# Rocket.toml file for tests/* and examples/*
 # Run: cargo run --example panic
 [global]
 sentry_dsn = "https://6b39979e27304cc3aa774f5b6811ce7d@sentry.io/1832690"

--- a/examples/panic.rs
+++ b/examples/panic.rs
@@ -1,7 +1,7 @@
-#![feature(proc_macro_hygiene, decl_macro)]
-
 #[macro_use]
 extern crate rocket;
+
+use rocket::{Build, Rocket};
 
 use rocket_sentry::RocketSentry;
 
@@ -10,9 +10,9 @@ fn panic(msg: Option<String>) -> String {
     panic!("{}", msg.unwrap_or("You asked for it!".to_string()));
 }
 
-fn main() {
-    rocket::ignite()
+#[launch]
+fn rocket() -> Rocket<Build> {
+    rocket::build()
         .attach(RocketSentry::fairing())
         .mount("/", routes![panic])
-        .launch();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,7 @@ impl Fairing for RocketSentry {
     fn info(&self) -> Info {
         Info {
             name: "rocket-sentry",
-            kind: Kind::Ignite,
+            kind: Kind::Ignite | Kind::Singleton,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,25 +13,27 @@
 //! =============
 //!
 //! ```no_run
+//! # #[macro_use]
+//! # extern crate rocket;
 //! use rocket_sentry::RocketSentry;
 //!
-//! fn main() {
-//!     rocket::ignite()
+//! # fn main() {
+//! #[launch]
+//! fn rocket() -> _ {
+//!     rocket::build()
 //!         .attach(RocketSentry::fairing())
 //!         // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   add this line
-//!         .launch();
 //! }
+//! # }
 //! ```
 //!
 //! Then, the Sentry integration can be enabled by adding a `sentry_dsn=` value to
 //! the `Rocket.toml` file, for example:
 //!
 //! ```toml
-//! [development]
+//! [debug]
 //! sentry_dsn = ""  # Disabled
-//! [staging]
-//! sentry_dsn = "https://057006d7dfe5fff0fbed461cfca5f757@sentry.io/1111111"
-//! [production]
+//! [release]
 //! sentry_dsn = "https://057006d7dfe5fff0fbed461cfca5f757@sentry.io/1111111"
 //! ```
 //!
@@ -41,11 +43,17 @@ extern crate log;
 use std::sync::Mutex;
 
 use rocket::fairing::{Fairing, Info, Kind};
-use rocket::Rocket;
+use rocket::serde::Deserialize;
+use rocket::{fairing, Build, Rocket};
 use sentry::ClientInitGuard;
 
 pub struct RocketSentry {
     guard: Mutex<Option<ClientInitGuard>>,
+}
+
+#[derive(Deserialize)]
+struct Config {
+    sentry_dsn: String,
 }
 
 impl RocketSentry {
@@ -70,24 +78,28 @@ impl RocketSentry {
     }
 }
 
+#[rocket::async_trait]
 impl Fairing for RocketSentry {
     fn info(&self) -> Info {
         Info {
             name: "rocket-sentry",
-            // Kind::Response is necessary, otherwise Rocket dealloc's our SentryGuard reference.
-            kind: Kind::Attach | Kind::Response,
+            kind: Kind::Ignite,
         }
     }
 
-    fn on_attach(&self, rocket: Rocket) -> Result<Rocket, Rocket> {
-        match rocket.config().get_str("sentry_dsn") {
-            Ok("") => {
-                info!("Sentry disabled.");
+    async fn on_ignite(&self, rocket: Rocket<Build>) -> fairing::Result {
+        let figment = rocket.figment();
+
+        let config: figment::error::Result<Config> = figment.extract();
+        match config {
+            Ok(config) => {
+                if config.sentry_dsn.is_empty() {
+                    info!("Sentry disabled.");
+                } else {
+                    self.init(&config.sentry_dsn);
+                }
             }
-            Ok(dsn) => {
-                self.init(dsn);
-            }
-            Err(err) => error!("Sentry disabled: {}", err),
+            Err(err) => error!("Sentry not configured: {}", err),
         }
         Ok(rocket)
     }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,12 +1,18 @@
-use rocket_sentry::RocketSentry;
 use sentry::Hub;
 
+use rocket_sentry::RocketSentry;
+
 /// Smoke test: check that sentry gets initialized by the fairing.
-#[test]
-fn fairing_init() {
+#[rocket::async_test]
+async fn fairing_init() {
     let hub = Hub::main();
     assert!(hub.client().is_none());
 
-    rocket::ignite().attach(RocketSentry::fairing());
+    let _rocket = rocket::build()
+        .attach(RocketSentry::fairing())
+        .ignite()
+        .await
+        .expect("Rocket failed to ignite");
+
     assert!(hub.client().is_some());
 }


### PR DESCRIPTION
Fixes #22

  * Now using figment and serde for configuration (both are required by Rocket)
  * The fairing no longer needs to have `Response` kind
  * RocketSentry now uses fairing kind `Singleton`
