### PR TITLE
Prepare for 0.9.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocket-sentry"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2018"
 
 # Metadata

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019-2021 Marti Raudsepp
+Copyright (c) 2019-2022 Marti Raudsepp
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ Or maybe...
 Features
 --------
 
-Currently, `rocket-sentry` only enables the Rust panic handler.
+Currently `rocket-sentry` is very basic, it only enables the Rust panic handler.
+There is no integration with the Rocket request lifecycle.
+Pull requests welcome!
 
 `rocket-sentry` can be configured via `Rocket.toml` (`sentry_dsn=`) or
 environment variable `ROCKET_SENTRY_DSN`.
@@ -65,6 +67,9 @@ http://localhost:8012/panic?msg=Is+it+time+to+panic+yet?
 
 Release history
 ---------------
+##### 0.9.0 (2022-01-22)
+* Update Rust crate sentry to 0.24.1 (#28) & patch updates
+
 ##### 0.8.0 (2021-11-22)
 * **Breaking change:** Update to Rocket version 0.5-rc
   * To continue using Rocket 0.4.x, stay with rocket-sentry 0.7.0


### PR DESCRIPTION
Clarified how basic rocket-sentry is in the README. (Refs #24)

Updated copyright dates.