### PR TITLE
Simple change: Use Default Sentry Settings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,10 +44,9 @@ use std::sync::Mutex;
 
 use rocket::fairing::{Fairing, Info, Kind};
 use rocket::serde::Deserialize;
+use rocket::Config;
 use rocket::{fairing, Build, Rocket};
 use sentry::ClientInitGuard;
-use rocket::Config;
-
 
 pub struct RocketSentry {
     guard: Mutex<Option<ClientInitGuard>>,
@@ -66,11 +65,14 @@ impl RocketSentry {
     }
 
     fn init(&self, dsn: &str) {
-        let guard = sentry::init((dsn, sentry::ClientOptions {
-            release: sentry::release_name!(),
-            environment: Some(String::from(Config::DEFAULT_PROFILE).into()),
-            ..Default::default()
-        }));
+        let guard = sentry::init((
+            dsn,
+            sentry::ClientOptions {
+                release: sentry::release_name!(),
+                environment: Some(String::from(Config::DEFAULT_PROFILE).into()),
+                ..Default::default()
+            },
+        ));
 
         if guard.is_enabled() {
             // Tuck the ClientInitGuard in the fairing, so it lives as long as the server.


### PR DESCRIPTION
Solves #35 

Uses the Default sentry settings as stated in Documentation of the Sentry crate. 

Allows replacement of info such as env and release by using environmental variables, as described in the docs:

https://docs.sentry.io/platforms/rust/configuration/options/

Very simple change but may solve some issues.

Example of addition below:

![image](https://user-images.githubusercontent.com/40151425/162799221-d52838d3-cf9a-4abe-876c-4c1396f9ee35.png)

Thanks!