### PR TITLE
Update to Rust 2021 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rocket-sentry"
 version = "0.10.0"
-edition = "2018"
+edition = "2021"
 
 # Metadata
 authors = ["Marti Raudsepp <marti@juffo.org>"]


### PR DESCRIPTION
Latest Rocket v0.5.0-rc.2 uses 2021, so no reason to keep this package back.