### PR TITLE
Add Performance Monitoring (transactions) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,16 @@ Or maybe...
 Features
 --------
 
-Currently `rocket-sentry` is very basic, it only enables the Rust panic handler.
-There is no integration with the Rocket request lifecycle.
+Currently `rocket-sentry` enables the Rust panic handler and support basic [transactions](https://docs.sentry.io/product/performance/transaction-summary/).  
+Transactions fields supported are:
+ - [X] HTTP method
+ - [X] GET query_string
+ - [ ] POST data
+ - [ ] cookies
+ - [ ] headers
+ - [ ] environment
+ - [ ] url
+
 Pull requests welcome!
 
 `rocket-sentry` can be configured via `Rocket.toml` (`sentry_dsn=`) or

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ Currently `rocket-sentry` enables the Rust panic handler and support basic [tran
 Transactions fields supported are:
  - [X] HTTP method
  - [X] GET query_string
+ - [X] headers
  - [ ] POST data
  - [ ] cookies
- - [ ] headers
  - [ ] environment
  - [ ] url
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ the `Rocket.toml` file, for example:
 sentry_dsn = ""  # Disabled
 [release]
 sentry_dsn = "https://057006d7dfe5fff0fbed461cfca5f757@sentry.io/1111111"
-sentry_transaction_sample_rate = 0.2  # 20% of requests will be logged under the performance tab
+sentry_traces_sample_rate = 0.2  # 20% of requests will be logged under the performance tab
 ```
 
 Testing

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ the `Rocket.toml` file, for example:
 sentry_dsn = ""  # Disabled
 [release]
 sentry_dsn = "https://057006d7dfe5fff0fbed461cfca5f757@sentry.io/1111111"
+sentry_transaction_sample_rate = 0.2  # 20% of requests will be logged under the performance tab
 ```
 
 Testing

--- a/Rocket.toml
+++ b/Rocket.toml
@@ -2,4 +2,5 @@
 # Run: cargo run --example panic
 [global]
 sentry_dsn = "https://6b39979e27304cc3aa774f5b6811ce7d@sentry.io/1832690"
+sentry_transaction_sample_rate = 1.0
 port = 8012

--- a/Rocket.toml
+++ b/Rocket.toml
@@ -2,5 +2,5 @@
 # Run: cargo run --example panic
 [global]
 sentry_dsn = "https://6b39979e27304cc3aa774f5b6811ce7d@sentry.io/1832690"
-sentry_transaction_sample_rate = 1.0
+sentry_traces_sample_rate = 1.0
 port = 8012

--- a/examples/performance.rs
+++ b/examples/performance.rs
@@ -1,0 +1,22 @@
+#[macro_use]
+extern crate rocket;
+
+use std::thread;
+use std::time::Duration;
+use rocket::{Build, Rocket};
+
+use rocket_sentry::RocketSentry;
+
+#[get("/performance")]
+fn panic() -> String {
+    let duration = Duration::from_millis(500);
+    thread::sleep(duration);
+    return format!("Waited {duration:?}");
+}
+
+#[launch]
+fn rocket() -> Rocket<Build> {
+    rocket::build()
+        .attach(RocketSentry::fairing())
+        .mount("/", routes![panic])
+}

--- a/examples/performance.rs
+++ b/examples/performance.rs
@@ -16,7 +16,7 @@ fn performance() -> String {
 
 #[get("/performance/<id>")]
 fn performance_with_id(id: u16) -> String {
-    // Wait as long as the id in secondes
+    // Wait as long as the id in seconds
     let duration = Duration::from_secs(id.into());
     thread::sleep(duration);
     return format!("Waited {duration:?} for id {id}");

--- a/examples/performance.rs
+++ b/examples/performance.rs
@@ -8,15 +8,22 @@ use rocket::{Build, Rocket};
 use rocket_sentry::RocketSentry;
 
 #[get("/performance")]
-fn panic() -> String {
+fn performance() -> String {
     let duration = Duration::from_millis(500);
     thread::sleep(duration);
     return format!("Waited {duration:?}");
+}
+
+#[get("/performance/<id>")]
+fn performance_with_id(id: u8) -> String {
+    let duration = Duration::from_millis(500);
+    thread::sleep(duration);
+    return format!("Waited {duration:?} for id {id}");
 }
 
 #[launch]
 fn rocket() -> Rocket<Build> {
     rocket::build()
         .attach(RocketSentry::fairing())
-        .mount("/", routes![panic])
+        .mount("/", routes![performance, performance_with_id])
 }

--- a/examples/performance.rs
+++ b/examples/performance.rs
@@ -22,9 +22,17 @@ fn performance_with_id(id: u16) -> String {
     return format!("Waited {duration:?} for id {id}");
 }
 
+#[get("/performance?<param1>&<param2>")]
+fn performance_with_parameter(param1: String, param2: u32) -> String {
+    let duration = Duration::from_millis(250);
+    thread::sleep(duration);
+    return format!("Waited {duration:?} for param {param1} - {param2}");
+}
+
+
 #[launch]
 fn rocket() -> Rocket<Build> {
     rocket::build()
         .attach(RocketSentry::fairing())
-        .mount("/", routes![performance, performance_with_id])
+        .mount("/", routes![performance, performance_with_id, performance_with_parameter])
 }

--- a/examples/performance.rs
+++ b/examples/performance.rs
@@ -1,9 +1,9 @@
 #[macro_use]
 extern crate rocket;
 
+use rocket::{Build, Rocket};
 use std::thread;
 use std::time::Duration;
-use rocket::{Build, Rocket};
 
 use rocket_sentry::RocketSentry;
 
@@ -29,10 +29,10 @@ fn performance_with_parameter(param1: String, param2: u32) -> String {
     return format!("Waited {duration:?} for param {param1} - {param2}");
 }
 
-
 #[launch]
 fn rocket() -> Rocket<Build> {
-    rocket::build()
-        .attach(RocketSentry::fairing())
-        .mount("/", routes![performance, performance_with_id, performance_with_parameter])
+    rocket::build().attach(RocketSentry::fairing()).mount(
+        "/",
+        routes![performance, performance_with_id, performance_with_parameter],
+    )
 }

--- a/examples/performance.rs
+++ b/examples/performance.rs
@@ -15,8 +15,9 @@ fn performance() -> String {
 }
 
 #[get("/performance/<id>")]
-fn performance_with_id(id: u8) -> String {
-    let duration = Duration::from_millis(500);
+fn performance_with_id(id: u16) -> String {
+    // Wait as long as the id in secondes
+    let duration = Duration::from_secs(id.into());
     thread::sleep(duration);
     return format!("Waited {duration:?} for id {id}");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,12 +44,12 @@ extern crate log;
 use std::sync::{Arc, Mutex};
 
 use rocket::fairing::{Fairing, Info, Kind};
-use rocket::serde::Deserialize;
-use rocket::{fairing, Build, Rocket, Request, Data, Response};
 use rocket::http::Status;
 use rocket::request::local_cache_once;
-use sentry::{ClientInitGuard, ClientOptions, protocol, Transaction};
+use rocket::serde::Deserialize;
+use rocket::{fairing, Build, Data, Request, Response, Rocket};
 use sentry::protocol::SpanStatus;
+use sentry::{protocol, ClientInitGuard, ClientOptions, Transaction};
 
 const TRANSACTION_OPERATION_NAME: &str = "http.server";
 
@@ -60,7 +60,7 @@ pub struct RocketSentry {
 #[derive(Deserialize)]
 struct Config {
     sentry_dsn: String,
-    sentry_traces_sample_rate: Option<f32>,  // Default is 0 so no transaction transmitted
+    sentry_traces_sample_rate: Option<f32>, // Default is 0 so no transaction transmitted
 }
 
 impl RocketSentry {
@@ -95,10 +95,7 @@ impl RocketSentry {
     }
 
     fn start_transaction(name: &str) -> Transaction {
-        let transaction_context = sentry::TransactionContext::new(
-            name,
-            TRANSACTION_OPERATION_NAME,
-        );
+        let transaction_context = sentry::TransactionContext::new(name, TRANSACTION_OPERATION_NAME);
         sentry::start_transaction(transaction_context)
     }
 
@@ -195,8 +192,8 @@ fn map_status(status: Status) -> SpanStatus {
 
 #[cfg(test)]
 mod tests {
-    use rocket::local::asynchronous::Client;
     use crate::{request_to_query_string, request_to_transaction_name};
+    use rocket::local::asynchronous::Client;
 
     #[rocket::async_test]
     async fn request_to_sentry_transaction_name_get_no_path() {
@@ -262,6 +259,9 @@ mod tests {
 
         let query_string = request_to_query_string(request.inner());
 
-        assert_eq!(query_string, Some("param1=value1&param2=value2".to_string()));
+        assert_eq!(
+            query_string,
+            Some("param1=value1&param2=value2".to_string())
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,7 +178,7 @@ fn map_status(status: Status) -> SpanStatus {
     match status.code {
         100..=299 => SpanStatus::Ok,
         // For 3xx there is no appropriate redirect status, so we default to Ok as flask does,
-        // See https://github.com/intgr/rocket-sentry/pull/59#discussion_r1367905267
+        // https://github.com/getsentry/sentry-python/blob/e0d7bb733b5db43531b1efae431669bfe9e63908/sentry_sdk/tracing.py#L408-L435
         300..=399 => SpanStatus::Ok,
         401 => SpanStatus::Unauthenticated,
         403 => SpanStatus::PermissionDenied,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,18 +195,19 @@ fn map_status(status: Status) -> SpanStatus {
 
 fn request_to_header_map(request: &Request) -> BTreeMap<String, String> {
     BTreeMap::from_iter(
-        request.headers().iter().map(
-            |header| (header.name().to_string(), header.value().to_string())
-        )
+        request
+            .headers()
+            .iter()
+            .map(|header| (header.name().to_string(), header.value().to_string())),
     )
 }
 
 #[cfg(test)]
 mod tests {
-    use rocket::http::Header;
     use crate::{request_to_header_map, request_to_query_string, request_to_transaction_name};
-    use rocket::local::asynchronous::Client;
     use rocket::http::ContentType;
+    use rocket::http::Header;
+    use rocket::local::asynchronous::Client;
 
     #[rocket::async_test]
     async fn request_to_sentry_transaction_name_get_no_path() {
@@ -293,13 +294,20 @@ mod tests {
     async fn request_to_header_map_multiple() {
         let rocket = rocket::build();
         let client = Client::tracked(rocket).await.unwrap();
-        let request = client.get("/")
+        let request = client
+            .get("/")
             .header(ContentType::JSON)
             .header(Header::new("custom-key", "custom-value"));
 
         let header_map = request_to_header_map(request.inner());
 
-        assert_eq!(header_map.get("custom-key"), Some(&"custom-value".to_string()));
-        assert_eq!(header_map.get("Content-Type"), Some(&"application/json".to_string()));
+        assert_eq!(
+            header_map.get("custom-key"),
+            Some(&"custom-value".to_string())
+        );
+        assert_eq!(
+            header_map.get("Content-Type"),
+            Some(&"application/json".to_string())
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,7 +176,9 @@ fn request_to_query_string(request: &Request) -> Option<String> {
 fn map_status(status: Status) -> SpanStatus {
     match status.code {
         100..=299 => SpanStatus::Ok,
-        300..=399 => SpanStatus::InvalidArgument,
+        // For 3xx there is no appropriate redirect status, so we default to Ok as flask does,
+        // See https://github.com/intgr/rocket-sentry/pull/59#discussion_r1367905267
+        300..=399 => SpanStatus::Ok,
         401 => SpanStatus::Unauthenticated,
         403 => SpanStatus::PermissionDenied,
         404 => SpanStatus::NotFound,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,6 +135,6 @@ impl Fairing for RocketSentry {
         let request_transaction = local_cache_once!(request, Self::build_transaction);
         let ongoing_transaction: &Transaction = request.local_cache(request_transaction);
         // TODO ongoing_transaction.set_status()
-        ongoing_transaction.clone().finish();  // TODO avoid the clone
+        ongoing_transaction.clone().finish();
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,8 +143,21 @@ impl Fairing for RocketSentry {
         let request_transaction = local_cache_once!(request, Self::invalid_transaction);
         let ongoing_transaction: &Transaction = request.local_cache(request_transaction);
         ongoing_transaction.set_status(map_status(response.status()));
+        set_transaction_method(ongoing_transaction, request);
         ongoing_transaction.clone().finish();
     }
+}
+
+fn set_transaction_method(transaction: &Transaction, request: &Request) {
+    transaction.set_request(protocol::Request {
+        url: None,
+        method: Some(String::from(request.method().as_str())),
+        data: None,
+        query_string: None,
+        cookies: None,
+        headers: Default::default(),
+        env: Default::default(),
+    });
 }
 
 fn request_to_transaction_name(request: &Request) -> String {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,17 +90,17 @@ impl RocketSentry {
         }
     }
 
-    fn build_transaction(name: &String) -> Transaction {
+    fn build_transaction(name: &str) -> Transaction {
         let transaction_context = sentry::TransactionContext::new(
-            name.as_str(),
+            name,
             TRANSACTION_OPERATION_NAME,
         );
         sentry::start_transaction(transaction_context)
     }
 
     fn invalid_transaction() -> Transaction {
-        let name = String::from("INVALID TRANSACTION");
-        Self::build_transaction(&name)
+        let name = "INVALID TRANSACTION";
+        Self::build_transaction(name)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,7 @@ impl RocketSentry {
         }
     }
 
-    fn build_transaction(name: &str) -> Transaction {
+    fn start_transaction(name: &str) -> Transaction {
         let transaction_context = sentry::TransactionContext::new(
             name,
             TRANSACTION_OPERATION_NAME,
@@ -101,9 +101,11 @@ impl RocketSentry {
         sentry::start_transaction(transaction_context)
     }
 
+    /// Same type as the underlying function so as to retrieve a transaction from the cache.
+    /// Should not be called but won't panic either.
     fn invalid_transaction() -> Transaction {
         let name = "INVALID TRANSACTION";
-        Self::build_transaction(name)
+        Self::start_transaction(name)
     }
 }
 
@@ -136,7 +138,7 @@ impl Fairing for RocketSentry {
 
     async fn on_request(&self, request: &mut Request<'_>, _: &mut Data<'_>) {
         let name = request_to_transaction_name(request);
-        let build_transaction = move || Self::build_transaction(&name);
+        let build_transaction = move || Self::start_transaction(&name);
         let request_transaction = local_cache_once!(request, build_transaction);
         request.local_cache(request_transaction);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@
 //! sentry_dsn = ""  # Disabled
 //! [release]
 //! sentry_dsn = "https://057006d7dfe5fff0fbed461cfca5f757@sentry.io/1111111"
+//! sentry_transaction_sample_rate = 0.2  # 20% of requests will be logged under the performance tab
 //! ```
 //!
 #[macro_use]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,7 +1,6 @@
-use rocket::local::asynchronous::Client;
 use sentry::Hub;
 
-use rocket_sentry::{request_to_transaction_name, RocketSentry};
+use rocket_sentry::RocketSentry;
 
 /// Smoke test: check that sentry gets initialized by the fairing.
 #[rocket::async_test]
@@ -16,38 +15,4 @@ async fn fairing_init() {
         .expect("Rocket failed to ignite");
 
     assert!(hub.client().is_some());
-}
-
-#[rocket::async_test]
-async fn request_to_sentry_transaction_name_get_no_path() {
-    let rocket = rocket::build();
-    let client = Client::tracked(rocket).await.unwrap();
-    let request = client.get("/");
-
-    let transaction_name = request_to_transaction_name(request.inner());
-
-    assert_eq!(transaction_name, "GET /");
-}
-
-#[rocket::async_test]
-async fn request_to_sentry_transaction_name_get_some_path() {
-    let rocket = rocket::build();
-    let client = Client::tracked(rocket).await.unwrap();
-    let request = client.get("/some/path");
-
-    let transaction_name = request_to_transaction_name(request.inner());
-
-    assert_eq!(transaction_name, "GET /some/path");
-}
-
-#[rocket::async_test]
-async fn request_to_sentry_transaction_name_post_path_with_variables() {
-    let rocket = rocket::build();
-    let client = Client::tracked(rocket).await.unwrap();
-    let request = client.post("/users/6");
-
-    let transaction_name = request_to_transaction_name(request.inner());
-
-    // Ideally, we should just returns /users/<id> as configured in the routes
-    assert_eq!(transaction_name, "POST /users/6");
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,6 +1,7 @@
+use rocket::local::asynchronous::Client;
 use sentry::Hub;
 
-use rocket_sentry::RocketSentry;
+use rocket_sentry::{request_to_transaction_name, RocketSentry};
 
 /// Smoke test: check that sentry gets initialized by the fairing.
 #[rocket::async_test]
@@ -15,4 +16,38 @@ async fn fairing_init() {
         .expect("Rocket failed to ignite");
 
     assert!(hub.client().is_some());
+}
+
+#[rocket::async_test]
+async fn request_to_sentry_transaction_name_get_no_path() {
+    let rocket = rocket::build();
+    let client = Client::tracked(rocket).await.unwrap();
+    let request = client.get("/");
+
+    let transaction_name = request_to_transaction_name(request.inner());
+
+    assert_eq!(transaction_name, "GET /");
+}
+
+#[rocket::async_test]
+async fn request_to_sentry_transaction_name_get_some_path() {
+    let rocket = rocket::build();
+    let client = Client::tracked(rocket).await.unwrap();
+    let request = client.get("/some/path");
+
+    let transaction_name = request_to_transaction_name(request.inner());
+
+    assert_eq!(transaction_name, "GET /some/path");
+}
+
+#[rocket::async_test]
+async fn request_to_sentry_transaction_name_post_path_with_variables() {
+    let rocket = rocket::build();
+    let client = Client::tracked(rocket).await.unwrap();
+    let request = client.post("/users/6");
+
+    let transaction_name = request_to_transaction_name(request.inner());
+
+    // Ideally, we should just returns /users/<id> as configured in the routes
+    assert_eq!(transaction_name, "POST /users/6");
 }


### PR DESCRIPTION
Hello, this PR add support for [performance/transaction](https://docs.sentry.io/platforms/rust/performance/instrumentation/custom-instrumentation/).
It requires `sentry_transaction_sample_rate` to be set with a value above 0, else transactions are not enabled.

A downside is that raw URI are used and so for a common route (with an id as parameter for example), transaction will not be aggregated. To fix it, we need to set the transaction name in the `on_response` callback as the routing is not yet done in `on_request`. But I didn't find a way to set a name to an existing transaction.  
A solution might be to start a span in the `on_request` and then create later the transaction with `sentry::continue_from_span`. I didn't test it though.

Anyway let me  know your thoughts and if there is anything you would like I change.