### PR TITLE
chore: release v0.15.1

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -1,0 +1,27 @@
+name: Release automation
+
+on:
+  push:
+    branches:
+      - main
+      - master
+
+jobs:
+  release-plz:
+    name: Release-plz
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_PLZ_TOKEN }}
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Run release-plz
+        uses: MarcoIeni/release-plz-action@v0.5
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+The format is similar to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.15.1] - 2023-11-19
+
+- **CI:** Set up release automation
+- **Documentation:** Move history to CHANGELOG.md and auto-generate it ([#60](https://github.com/intgr/rocket-sentry/pull/60))
+- Add Performance Monitoring (transactions) support ([#59](https://github.com/intgr/rocket-sentry/pull/59))
+- **Dependency:** Update Rust crate sentry to 0.31.7 ([#57](https://github.com/intgr/rocket-sentry/pull/57))
+
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
 The format is similar to [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocket-sentry"
-version = "0.15.0"
+version = "0.15.1"
 edition = "2021"
 rust-version = "1.64.0"
 

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,9 @@
+[workspace]
+# git-cliff configuration
+changelog_config = "cliff.toml"
+changelog_update = true
+git_tag_enable = true
+# GitHub releases are handled by `cargo-dist`
+git_release_enable = false
+pr_labels = ["release"]
+semver_check = true


### PR DESCRIPTION
## 🤖 New release
* `rocket-sentry`: 0.15.0 -> 0.15.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.15.1] - 2023-11-19

- **CI:** Set up release automation
- **Documentation:** Move history to CHANGELOG.md and auto-generate it ([#60](https://github.com/intgr/rocket-sentry/pull/60))
- Add Performance Monitoring (transactions) support ([#59](https://github.com/intgr/rocket-sentry/pull/59))
- **Dependency:** Update Rust crate sentry to 0.31.7 ([#57](https://github.com/intgr/rocket-sentry/pull/57))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).