### PR TITLE
ci: fix clippy checks in CI

### DIFF
--- a/varia/Dockerfile.tests
+++ b/varia/Dockerfile.tests
@@ -6,6 +6,8 @@ WORKDIR /root/build
 # Make warnings fatal
 ENV RUSTFLAGS="-D warnings"
 
+RUN rustup component add rustfmt clippy
+
 # Build Cargo dependencies for cache
 COPY Cargo.toml ./
 RUN mkdir src/ && \


### PR DESCRIPTION
I'm not sure how this worked before, but `clippy` and `rustfmt` aren't included in Rust's official Docker images. I guess the `nightly` image was different/special somehow, but since stopped working.