### PR TITLE
feat: Performance Monitoring traces sampler callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,10 @@ sentry_dsn = "https://057006d7dfe5fff0fbed461cfca5f757@sentry.io/1111111"
 sentry_traces_sample_rate = 0.2  # 20% of requests will be logged under the performance tab
 ```
 
-`traces_sampler` can be used instead of `sentry_traces_sample_rate` to have a more granular control, [see details here](https://docs.sentry.io/platforms/rust/configuration/sampling/#configuring-the-transaction-sample-rate).
+### Performance Monitoring
+
+`traces_sampler` can be used instead of `sentry_traces_sample_rate` to have a more granular control over performance monitoring,
+[see Sentry documentation](https://docs.sentry.io/platforms/rust/configuration/sampling/#configuring-the-transaction-sample-rate).
 ```rust
 use rocket_sentry::RocketSentry;
 
@@ -75,7 +78,7 @@ use rocket_sentry::RocketSentry;
 fn rocket() -> _ {
     let traces_sampler = move |ctx: &TransactionContext| -> f32 {
         match ctx.name() {
-            path if matches!(path, "GET /specific/path/1" | "GET /specific/path/2") => 0.,  // Drop the performance transaction
+            "GET /specific/path/1" | "GET /specific/path/2" => 0.,  // Drop the performance transaction
             _ => 1.,
         }
     };

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Currently `rocket-sentry` includes two integrations:
 
 * **Rust panic handler:** when a panic happens, it is reported as a Sentry event.
 * **Performance Monitoring:** HTTP requests are reported as [Transactions](https://docs.sentry.io/product/performance/transaction-summary/),
-  if the `sentry_traces_sample_rate` setting is configured or `traces_sampler` is used (see example below).
+  if the `sentry_traces_sample_rate` setting is configured or `traces_sampler` callback is provided (see example below).
 
   Transactions currently include the following fields:
   - [X] HTTP method
@@ -77,7 +77,7 @@ fn rocket() -> _ {
     let default_rate = rocket_instance.figment().extract_inner::<f32>("sentry_traces_sample_rate").unwrap();
     let traces_sampler = move |ctx: &TransactionContext| -> f32 {
         if matches!(ctx.name(), "GET /specific/path/1" | "GET /specific/path/2") {
-            log::debug!("Dropping performance transaction");
+            // Drop the performance transaction
             0.
         } else {
             log::debug!("Sending performance transaction using the rate set in the config");
@@ -88,7 +88,6 @@ fn rocket() -> _ {
 
     rocket_instance
         .attach(rocket_sentry)
-    // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   add this line
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ fn rocket() -> _ {
         }
     };
     rocket::build()
-        .attach(RocketSentry::default().set_traces_sampler(Arc::new(traces_sampler)));
+        .attach(RocketSentry::builder().traces_sampler(Arc::new(traces_sampler)).build());
 }
 ```
 See [a more advanced example](examples/performance.rs).

--- a/examples/performance.rs
+++ b/examples/performance.rs
@@ -64,7 +64,9 @@ fn rocket() -> Rocket<Build> {
             default_rate
         }
     };
-    let rocket_sentry = RocketSentry::new().set_traces_sampler(Arc::new(traces_sampler));
+    let rocket_sentry = RocketSentry::builder()
+        .traces_sampler(Arc::new(traces_sampler))
+        .build();
     rocket_instance.attach(rocket_sentry).mount(
         "/",
         routes![

--- a/examples/performance.rs
+++ b/examples/performance.rs
@@ -38,7 +38,7 @@ fn performance_skipped() -> String {
     return format!("Waited {duration:?}\nTransaction will be dropped");
 }
 
-#[get("/performance/rng")]
+#[get("/performance/random")]
 fn performance_rng() -> String {
     let duration = Duration::from_millis(100);
     thread::sleep(duration);
@@ -48,6 +48,7 @@ fn performance_rng() -> String {
 #[launch]
 fn rocket() -> Rocket<Build> {
     let rocket_instance = rocket::build();
+    // Get the default configured sample rate from `Rocket.toml`
     let default_rate = rocket_instance
         .figment()
         .extract_inner::<f32>("sentry_traces_sample_rate")

--- a/examples/performance.rs
+++ b/examples/performance.rs
@@ -54,15 +54,19 @@ fn rocket() -> Rocket<Build> {
         .extract_inner::<f32>("sentry_traces_sample_rate")
         .unwrap();
     let traces_sampler = move |ctx: &TransactionContext| -> f32 {
-        if ctx.name().to_lowercase().contains("skip") {
-            log::warn!("Dropping performance transaction");
-            0.
-        } else if ctx.name().to_lowercase().contains("rng") {
-            log::warn!("Sending performance transaction half the time");
-            0.5
-        } else {
-            log::warn!("Sending performance transaction using default rate");
-            default_rate
+        match ctx.name() {
+            "GET /performance/skip" => {
+                log::warn!("Dropping performance transaction");
+                0.
+            }
+            "GET /performance/random" => {
+                log::warn!("Sending performance transaction half the time");
+                0.
+            }
+            _ => {
+                log::warn!("Sending performance transaction using default rate");
+                default_rate
+            }
         }
     };
     let rocket_sentry = RocketSentry::builder()

--- a/examples/performance.rs
+++ b/examples/performance.rs
@@ -1,11 +1,11 @@
 #[macro_use]
 extern crate rocket;
 
-use std::sync::Arc;
 use rocket::{Build, Rocket};
+use sentry::TransactionContext;
+use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
-use sentry::TransactionContext;
 
 use rocket_sentry::RocketSentry;
 
@@ -48,7 +48,10 @@ fn performance_rng() -> String {
 #[launch]
 fn rocket() -> Rocket<Build> {
     let rocket_instance = rocket::build();
-    let default_rate = rocket_instance.figment().extract_inner::<f32>("sentry_traces_sample_rate").unwrap();
+    let default_rate = rocket_instance
+        .figment()
+        .extract_inner::<f32>("sentry_traces_sample_rate")
+        .unwrap();
     let traces_sampler = move |ctx: &TransactionContext| -> f32 {
         if ctx.name().to_lowercase().contains("skip") {
             log::warn!("Dropping performance transaction");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@ use rocket::request::local_cache_once;
 use rocket::serde::Deserialize;
 use rocket::{fairing, Build, Data, Request, Response, Rocket};
 use sentry::protocol::SpanStatus;
-use sentry::{protocol, ClientInitGuard, ClientOptions, Transaction, TracesSampler};
+use sentry::{protocol, ClientInitGuard, ClientOptions, TracesSampler, Transaction};
 
 const TRANSACTION_OPERATION_NAME: &str = "http.server";
 
@@ -235,14 +235,16 @@ fn request_to_header_map(request: &Request) -> BTreeMap<String, String> {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-    use std::sync::atomic::Ordering;
     use rocket::http::ContentType;
     use rocket::http::Header;
     use rocket::local::asynchronous::Client;
     use sentry::TransactionContext;
+    use std::sync::atomic::Ordering;
+    use std::sync::Arc;
 
-    use crate::{request_to_header_map, request_to_query_string, request_to_transaction_name, RocketSentry};
+    use crate::{
+        request_to_header_map, request_to_query_string, request_to_transaction_name, RocketSentry,
+    };
 
     #[rocket::async_test]
     async fn request_to_sentry_transaction_name_get_no_path() {
@@ -353,7 +355,10 @@ mod tests {
 
         rocket_sentry.init("https://user@some.dsn/123", 0.);
 
-        assert_eq!(rocket_sentry.transactions_enabled.load(Ordering::Relaxed), false);
+        assert_eq!(
+            rocket_sentry.transactions_enabled.load(Ordering::Relaxed),
+            false
+        );
     }
 
     #[rocket::async_test]
@@ -362,19 +367,25 @@ mod tests {
 
         rocket_sentry.init("https://user@some.dsn/123", 0.01);
 
-        assert_eq!(rocket_sentry.transactions_enabled.load(Ordering::Relaxed), true);
+        assert_eq!(
+            rocket_sentry.transactions_enabled.load(Ordering::Relaxed),
+            true
+        );
     }
 
     #[rocket::async_test]
     async fn transactions_enabled_by_traces_sampler() {
         let rocket_sentry = RocketSentry::new().set_traces_sampler(Arc::new(
             move |_: &TransactionContext| -> f32 {
-                0.  // Even a sampler that deny all transaction will mark transactions as enabled
-            }
+                0. // Even a sampler that deny all transaction will mark transactions as enabled
+            },
         ));
 
         rocket_sentry.init("https://user@some.dsn/123", 0.);
 
-        assert_eq!(rocket_sentry.transactions_enabled.load(Ordering::Relaxed), true);
+        assert_eq!(
+            rocket_sentry.transactions_enabled.load(Ordering::Relaxed),
+            true
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,12 +78,6 @@ impl RocketSentry {
         RocketSentryBuilder::default()
     }
 
-    #[must_use]
-    pub fn set_traces_sampler(mut self, traces_sampler: Arc<TracesSampler>) -> Self {
-        self.traces_sampler = Some(traces_sampler);
-        self
-    }
-
     fn init(&self, dsn: &str, traces_sample_rate: f32) {
         let guard = sentry::init((
             dsn,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@ struct Config {
 
 impl RocketSentry {
     #[must_use]
-    pub fn fairing() -> RocketSentry {
+    pub fn fairing() -> impl Fairing {
         RocketSentry::builder().build()
     }
 
@@ -370,7 +370,7 @@ mod tests {
     /// Transaction are only enabled on either a positive traces_sample_rate or a set traces_sampler
     #[rocket::async_test]
     async fn transactions_not_enabled() {
-        let rocket_sentry = RocketSentry::fairing();
+        let rocket_sentry = RocketSentry::builder().build();
 
         rocket_sentry.init("https://user@some.dsn/123", 0.);
 
@@ -382,7 +382,7 @@ mod tests {
 
     #[rocket::async_test]
     async fn transactions_enabled_by_traces_sample_rate() {
-        let rocket_sentry = RocketSentry::fairing();
+        let rocket_sentry = RocketSentry::builder().build();
 
         rocket_sentry.init("https://user@some.dsn/123", 0.01);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,7 @@ impl RocketSentry {
 
     #[must_use]
     pub fn builder() -> RocketSentryBuilder {
-        RocketSentryBuilder::default()
+        RocketSentryBuilder::new()
     }
 
     fn init(&self, dsn: &str, traces_sample_rate: f32) {
@@ -217,14 +217,13 @@ fn request_to_header_map(request: &Request) -> BTreeMap<String, String> {
         .collect()
 }
 
-#[derive(Default)]
 pub struct RocketSentryBuilder {
     traces_sampler: Option<Arc<TracesSampler>>,
 }
 
 impl RocketSentryBuilder {
     #[must_use]
-    pub fn new() -> RocketSentryBuilder {
+    fn new() -> RocketSentryBuilder {
         RocketSentryBuilder {
             traces_sampler: None,
         }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,5 +1,5 @@
-use std::sync::Arc;
 use sentry::{Hub, TransactionContext};
+use std::sync::Arc;
 
 use rocket_sentry::RocketSentry;
 
@@ -42,4 +42,3 @@ async fn fairing_init_with_specific_traces_sampler() {
 
     assert!(hub.client().is_some());
 }
-

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -6,7 +6,7 @@ use rocket_sentry::RocketSentry;
 /// Smoke test: check that sentry gets initialized by the fairing.
 #[rocket::async_test]
 async fn fairing_init() {
-    let hub = Hub::main();
+    let hub = Hub::current();
     assert!(hub.client().is_none());
 
     let _rocket = rocket::build()
@@ -20,7 +20,7 @@ async fn fairing_init() {
 
 #[rocket::async_test]
 async fn fairing_init_with_specific_traces_sampler() {
-    let hub = Hub::main();
+    let hub = Hub::current();
     assert!(hub.client().is_none());
 
     let traces_sampler = move |ctx: &TransactionContext| -> f32 {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,4 +1,5 @@
-use sentry::Hub;
+use std::sync::Arc;
+use sentry::{Hub, TransactionContext};
 
 use rocket_sentry::RocketSentry;
 
@@ -16,3 +17,29 @@ async fn fairing_init() {
 
     assert!(hub.client().is_some());
 }
+
+#[rocket::async_test]
+async fn fairing_init_with_specific_traces_sampler() {
+    let hub = Hub::main();
+    assert!(hub.client().is_none());
+
+    let traces_sampler = move |ctx: &TransactionContext| -> f32 {
+        if matches!(ctx.name(), "GET /specific/path/1" | "GET /specific/path/2") {
+            log::debug!("Dropping performance transaction");
+            0.
+        } else {
+            log::debug!("Sending performance transaction 80% of the time");
+            0.8
+        }
+    };
+    let rocket_sentry = RocketSentry::default().set_traces_sampler(Arc::new(traces_sampler));
+
+    let _rocket = rocket::build()
+        .attach(rocket_sentry)
+        .ignite()
+        .await
+        .expect("Rocket failed to ignite");
+
+    assert!(hub.client().is_some());
+}
+

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -32,7 +32,9 @@ async fn fairing_init_with_specific_traces_sampler() {
             0.8
         }
     };
-    let rocket_sentry = RocketSentry::default().set_traces_sampler(Arc::new(traces_sampler));
+    let rocket_sentry = RocketSentry::builder()
+        .traces_sampler(Arc::new(traces_sampler))
+        .build();
 
     let _rocket = rocket::build()
         .attach(rocket_sentry)

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -24,12 +24,15 @@ async fn fairing_init_with_specific_traces_sampler() {
     assert!(hub.client().is_none());
 
     let traces_sampler = move |ctx: &TransactionContext| -> f32 {
-        if matches!(ctx.name(), "GET /specific/path/1" | "GET /specific/path/2") {
-            log::debug!("Dropping performance transaction");
-            0.
-        } else {
-            log::debug!("Sending performance transaction 80% of the time");
-            0.8
+        match ctx.name() {
+            "GET /specific/path/1" | "GET /specific/path/2" => {
+                log::debug!("Dropping performance transaction");
+                0.
+            }
+            _ => {
+                log::debug!("Sending performance transaction 80% of the time");
+                0.8
+            }
         }
     };
     let rocket_sentry = RocketSentry::builder()


### PR DESCRIPTION
Following discussion in #73 , this should allow the usage of `traces_sampler` as exposed by Sentry.  
I kept the `fairing` method for compatibility.  
I need to check the `fairing_init_with_specific_traces_sampler` that seems to be failing for some reasons.
