### PR TITLE
feat: Pass environment name to Sentry

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[env]
+RUST_TEST_THREADS = "1"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,0 @@
-[env]
-RUST_TEST_THREADS = "1"

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ Currently `rocket-sentry` includes two integrations:
   - [X] HTTP method
   - [X] GET query string
   - [X] headers
+  - [X] environment
   - [ ] POST data
   - [ ] cookies
-  - [ ] environment
   - [ ] URL
 
 Pull requests welcome!

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Currently `rocket-sentry` includes two integrations:
   - [X] HTTP method
   - [X] GET query string
   - [X] headers
-  - [X] environment
+  - [X] environment name (based on Rocket configuration profile)
   - [ ] POST data
   - [ ] cookies
   - [ ] URL

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -270,7 +270,6 @@ mod tests {
 
     const DEFAULT_ENV: &'static str = "TEST";
 
-
     #[rocket::async_test]
     async fn request_to_sentry_transaction_name_get_no_path() {
         let rocket = rocket::build();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -257,11 +257,11 @@ impl RocketSentryBuilder {
 
 #[cfg(test)]
 mod tests {
-    use std::borrow::Cow;
     use rocket::http::ContentType;
     use rocket::http::Header;
     use rocket::local::asynchronous::Client;
     use sentry::TransactionContext;
+    use std::borrow::Cow;
     use std::sync::atomic::Ordering;
     use std::sync::Arc;
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -24,6 +24,7 @@ async fn fairing_init() {
 #[rocket::async_test]
 async fn fairing_init_with_specific_traces_sampler() {
     let hub = Hub::current();
+    assert!(hub.client().is_none());
 
     let traces_sampler = move |ctx: &TransactionContext| -> f32 {
         match ctx.name() {
@@ -47,8 +48,7 @@ async fn fairing_init_with_specific_traces_sampler() {
         .await
         .expect("Rocket failed to ignite");
 
-    let sentry_client = hub.client().unwrap();
-    assert!(sentry_client.options().traces_sampler.is_some());
+    assert!(hub.client().is_some());
 }
 
 async fn init_rocket_using_figment(figment: Figment) {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,6 +1,7 @@
 use sentry::{Hub, TransactionContext};
 use std::sync::Arc;
-
+use figment::Figment;
+use rocket::Config;
 use rocket_sentry::RocketSentry;
 
 /// Smoke test: check that sentry gets initialized by the fairing.
@@ -46,4 +47,54 @@ async fn fairing_init_with_specific_traces_sampler() {
         .expect("Rocket failed to ignite");
 
     assert!(hub.client().is_some());
+}
+
+#[rocket::async_test]
+async fn fairing_init_with_default_environment() {
+    let _rocket = rocket::build()
+        .attach(RocketSentry::fairing())
+        .ignite()
+        .await
+        .expect("Rocket failed to ignite");
+    let client = Hub::current().client().unwrap();
+    let client_options = client.options();
+    let environment = client_options.environment.clone().unwrap().to_string();
+
+    assert_eq!(environment, "development");  // default to development for debug build
+}
+
+#[rocket::async_test]
+async fn fairing_init_with_release_environment() {
+    let figment = Figment::from(Config::release_default())
+        .join(("sentry_dsn", "https://123@sentry.io/456"));
+    let _rocket = rocket::custom(figment)
+        .attach(RocketSentry::fairing())
+        .ignite()
+        .await
+        .expect("Rocket failed to ignite");
+    let client = Hub::current().client().unwrap();
+    let client_options = client.options();
+    let environment = client_options.environment.clone().unwrap().to_string();
+
+    assert_eq!(environment, "production");  // default to production for release build
+}
+
+#[rocket::async_test]
+async fn fairing_init_with_custom_environment() {
+    let profile_name = "staging";
+    let figment = Figment::new().select(profile_name)
+        .join(Config::debug_default())
+        .join(("sentry_dsn", "https://123@sentry.io/456"));
+
+
+    let _rocket = rocket::custom(figment)
+        .attach(RocketSentry::fairing())
+        .ignite()
+        .await
+        .expect("Rocket failed to ignite");
+    let client = Hub::current().client().unwrap();
+    let client_options = client.options();
+    let environment = client_options.environment.clone().unwrap().to_string();
+
+    assert_eq!(environment, profile_name);  // Rocket profile name was passed to Sentry config
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -24,7 +24,6 @@ async fn fairing_init() {
 #[rocket::async_test]
 async fn fairing_init_with_specific_traces_sampler() {
     let hub = Hub::current();
-    assert!(hub.client().is_none());
 
     let traces_sampler = move |ctx: &TransactionContext| -> f32 {
         match ctx.name() {
@@ -48,7 +47,8 @@ async fn fairing_init_with_specific_traces_sampler() {
         .await
         .expect("Rocket failed to ignite");
 
-    assert!(hub.client().is_some());
+    let sentry_client = hub.client().unwrap();
+    assert!(sentry_client.options().traces_sampler.is_some());
 }
 
 async fn init_rocket_using_figment(figment: Figment) {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,8 +1,10 @@
-use sentry::{Hub, TransactionContext};
-use std::sync::Arc;
 use figment::Figment;
 use rocket::Config;
 use rocket_sentry::RocketSentry;
+use sentry::{Hub, TransactionContext};
+use std::sync::Arc;
+
+const SENTRY_DSN_CONFIG: (&str, &str) = ("sentry_dsn", "https://123@sentry.io/456");
 
 /// Smoke test: check that sentry gets initialized by the fairing.
 #[rocket::async_test]
@@ -50,23 +52,8 @@ async fn fairing_init_with_specific_traces_sampler() {
 }
 
 #[rocket::async_test]
-async fn fairing_init_with_default_environment() {
-    let _rocket = rocket::build()
-        .attach(RocketSentry::fairing())
-        .ignite()
-        .await
-        .expect("Rocket failed to ignite");
-    let client = Hub::current().client().unwrap();
-    let client_options = client.options();
-    let environment = client_options.environment.clone().unwrap().to_string();
-
-    assert_eq!(environment, "development");  // default to development for debug build
-}
-
-#[rocket::async_test]
-async fn fairing_init_with_release_environment() {
-    let figment = Figment::from(Config::release_default())
-        .join(("sentry_dsn", "https://123@sentry.io/456"));
+async fn fairing_init_with_debug_rocket_profile() {
+    let figment = Figment::from(Config::debug_default()).join(SENTRY_DSN_CONFIG);
     let _rocket = rocket::custom(figment)
         .attach(RocketSentry::fairing())
         .ignite()
@@ -76,16 +63,31 @@ async fn fairing_init_with_release_environment() {
     let client_options = client.options();
     let environment = client_options.environment.clone().unwrap().to_string();
 
-    assert_eq!(environment, "production");  // default to production for release build
+    assert_eq!(environment, "development"); // default to development for debug build
 }
 
 #[rocket::async_test]
-async fn fairing_init_with_custom_environment() {
+async fn fairing_init_with_release_rocket_profile() {
+    let figment = Figment::from(Config::release_default()).join(SENTRY_DSN_CONFIG);
+    let _rocket = rocket::custom(figment)
+        .attach(RocketSentry::fairing())
+        .ignite()
+        .await
+        .expect("Rocket failed to ignite");
+    let client = Hub::current().client().unwrap();
+    let client_options = client.options();
+    let environment = client_options.environment.clone().unwrap().to_string();
+
+    assert_eq!(environment, "production"); // default to production for release build
+}
+
+#[rocket::async_test]
+async fn fairing_init_with_custom_rocket_profile() {
     let profile_name = "staging";
-    let figment = Figment::new().select(profile_name)
+    let figment = Figment::new()
+        .select(profile_name)
         .join(Config::debug_default())
-        .join(("sentry_dsn", "https://123@sentry.io/456"));
-
+        .join(SENTRY_DSN_CONFIG);
 
     let _rocket = rocket::custom(figment)
         .attach(RocketSentry::fairing())
@@ -96,5 +98,5 @@ async fn fairing_init_with_custom_environment() {
     let client_options = client.options();
     let environment = client_options.environment.clone().unwrap().to_string();
 
-    assert_eq!(environment, profile_name);  // Rocket profile name was passed to Sentry config
+    assert_eq!(environment, profile_name); // Rocket profile name was passed to Sentry config
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -24,7 +24,6 @@ async fn fairing_init() {
 #[rocket::async_test]
 async fn fairing_init_with_specific_traces_sampler() {
     let hub = Hub::current();
-    assert!(hub.client().is_none());
 
     let traces_sampler = move |ctx: &TransactionContext| -> f32 {
         match ctx.name() {
@@ -48,7 +47,8 @@ async fn fairing_init_with_specific_traces_sampler() {
         .await
         .expect("Rocket failed to ignite");
 
-    assert!(hub.client().is_some());
+    let sentry_client = hub.client().unwrap();
+    assert!(sentry_client.options().traces_sampler.is_some());
 }
 
 #[rocket::async_test]


### PR DESCRIPTION
I continued the work done in https://github.com/intgr/rocket-sentry/pull/36 by @FxllenCode to have Rocket profile name set as Sentry's environment.

For compatibility, I mapped `debug`/`release` to `development`/`production`. Running Rocket with something like `ROCKET_PROFILE=staging` as env vars will set this name in the environment tag on Sentry side.

For tests I started using env var but as tests run in parallel it is quite cumbersome to manage, so I resorted to using programmatic configs.

Close #35.