### PR TITLE
chore(clippy): run Clippy with all targets & features; fix warnings

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,6 +22,6 @@ jobs:
       - name: Test suite
         run: docker run --rm rocket-sentry-build cargo test --color=always
       - name: Clippy lints
-        run: docker run --rm rocket-sentry-build cargo clippy --color=always
+        run: docker run --rm rocket-sentry-build cargo clippy --color=always --all-targets --all-features
       - name: rustfmt
         run: docker run --rm rocket-sentry-build cargo fmt -- --color=always --check

--- a/examples/performance.rs
+++ b/examples/performance.rs
@@ -13,7 +13,7 @@ use rocket_sentry::RocketSentry;
 fn performance() -> String {
     let duration = Duration::from_millis(500);
     thread::sleep(duration);
-    return format!("Waited {duration:?}");
+    format!("Waited {duration:?}")
 }
 
 #[get("/performance/<id>")]
@@ -21,28 +21,28 @@ fn performance_with_id(id: u16) -> String {
     // Wait as long as the id in seconds
     let duration = Duration::from_secs(id.into());
     thread::sleep(duration);
-    return format!("Waited {duration:?} for id {id}");
+    format!("Waited {duration:?} for id {id}")
 }
 
 #[get("/performance?<param1>&<param2>")]
 fn performance_with_parameter(param1: String, param2: u32) -> String {
     let duration = Duration::from_millis(250);
     thread::sleep(duration);
-    return format!("Waited {duration:?} for param {param1} - {param2}");
+    format!("Waited {duration:?} for param {param1} - {param2}")
 }
 
 #[get("/performance/skip")]
 fn performance_skipped() -> String {
     let duration = Duration::from_millis(100);
     thread::sleep(duration);
-    return format!("Waited {duration:?}\nTransaction will be dropped");
+    format!("Waited {duration:?}\nTransaction will be dropped")
 }
 
 #[get("/performance/random")]
 fn performance_rng() -> String {
     let duration = Duration::from_millis(100);
     thread::sleep(duration);
-    return format!("Waited {duration:?}\nTransaction MIGHT be dropped");
+    format!("Waited {duration:?}\nTransaction MIGHT be dropped")
 }
 
 #[launch]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,7 @@
 #![warn(clippy::pedantic)]
+#![warn(clippy::cargo)]
+#![allow(clippy::multiple_crate_versions)]
+
 //! **rocket-sentry** is a simple add-on for the **Rocket** web framework to simplify
 //! integration with the **Sentry** application monitoring system.
 //!
@@ -151,7 +154,7 @@ impl Fairing for RocketSentry {
                     self.init(&config.sentry_dsn, traces_sample_rate, environment);
                 }
             }
-            Err(err) => error!("Sentry not configured: {}", err),
+            Err(err) => error!("Sentry not configured: {err}"),
         }
         Ok(rocket)
     }
@@ -380,10 +383,7 @@ mod tests {
 
         rocket_sentry.init("https://user@some.dsn/123", 0., DEFAULT_ENV);
 
-        assert_eq!(
-            rocket_sentry.transactions_enabled.load(Ordering::Relaxed),
-            false
-        );
+        assert!(!rocket_sentry.transactions_enabled.load(Ordering::Relaxed));
     }
 
     #[rocket::async_test]
@@ -392,10 +392,7 @@ mod tests {
 
         rocket_sentry.init("https://user@some.dsn/123", 0.01, DEFAULT_ENV);
 
-        assert_eq!(
-            rocket_sentry.transactions_enabled.load(Ordering::Relaxed),
-            true
-        );
+        assert!(rocket_sentry.transactions_enabled.load(Ordering::Relaxed));
     }
 
     #[rocket::async_test]
@@ -408,9 +405,6 @@ mod tests {
 
         rocket_sentry.init("https://user@some.dsn/123", 0., DEFAULT_ENV);
 
-        assert_eq!(
-            rocket_sentry.transactions_enabled.load(Ordering::Relaxed),
-            true
-        );
+        assert!(rocket_sentry.transactions_enabled.load(Ordering::Relaxed));
     }
 }


### PR DESCRIPTION
* Turns out clippy needs `--all-targets --all-features` flags to check examples and `cfg(tests)`
* Enabled `clippy::cargo` lints group
* Fixed all found warnings
