### PR TITLE
build: adjust Dockerfile to new Cargo build-dir layout

### DIFF
--- a/varia/Dockerfile.tests
+++ b/varia/Dockerfile.tests
@@ -11,9 +11,10 @@ RUN rustup component add rustfmt clippy
 # Build Cargo dependencies for cache
 COPY Cargo.toml ./
 RUN mkdir src/ && \
-	echo "pub fn main() {println!(\"dummy function\")}" > src/lib.rs && \
+	echo 'pub fn main() {println!("dummy function")}' > src/lib.rs && \
 	cargo build --lib --tests --examples --color=always && \
-	rm -rdv target/*/deps/rocket_sentry-* \
+	rm -rfv target/*/build/rocket-sentry \
+	        target/*/deps/rocket_sentry-* \
 	        target/*/.fingerprint/rocket-sentry-*
 
 # Do the actual build


### PR DESCRIPTION
Cargo layout change: https://github.com/rust-lang/cargo/issues/15010 (now enabled in nightly)

Determined that `rm` is still needed: Cargo rebuilds a crate only if a source file's mtime is newer than the previous build's start time.

Docker `COPY` preserves the real `src/lib.rs` mtime, which would be older than the dummy build's start — so Cargo wrongly deems the crate fresh and skips rebuild.